### PR TITLE
Added iOS 8 support (now requesting whenInUseAuthorization)

### DIFF
--- a/KCSIBeacon/KCSBeaconManager.m
+++ b/KCSIBeacon/KCSBeaconManager.m
@@ -108,6 +108,12 @@ NSString* const KCSIBeaconErrorDomain = @"KCSIBeaconErrorDomain";
         return NO;
     }
     
+    if ([self.locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
+        if ([CLLocationManager authorizationStatus] != kCLAuthorizationStatusAuthorizedWhenInUse) {
+            [self.locationManager requestWhenInUseAuthorization];
+        }
+    }
+
     CLAuthorizationStatus authStatus = [CLLocationManager authorizationStatus];
     if (authStatus == kCLAuthorizationStatusDenied) {
         if (error) {


### PR DESCRIPTION
Updated KCSIBeacon so that it works with the new permission system in iOS 8:

https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocationManager_Class/index.html?hl=it#//apple_ref/occ/instm/CLLocationManager/requestWhenInUseAuthorization
